### PR TITLE
修复话题列表刷新逻辑

### DIFF
--- a/app/src/main/java/com/randy/client/v2hot/TitleListActivity.java
+++ b/app/src/main/java/com/randy/client/v2hot/TitleListActivity.java
@@ -2,147 +2,135 @@ package com.randy.client.v2hot;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Adapter;
 import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.ListView;
-import android.widget.ProgressBar;
 import android.widget.SimpleAdapter;
-import android.widget.TextView;
 import android.widget.Toast;
 
-import com.android.volley.AuthFailureError;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonArrayRequest;
-import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import uk.co.senab.actionbarpulltorefresh.library.ActionBarPullToRefresh;
-import uk.co.senab.actionbarpulltorefresh.library.PullToRefreshAttacher;
 import uk.co.senab.actionbarpulltorefresh.library.PullToRefreshLayout;
 import uk.co.senab.actionbarpulltorefresh.library.listeners.OnRefreshListener;
 
-
 public class TitleListActivity extends Activity {
-
-    private ListView lv_title;
-    private ProgressBar pb_load;
-    private List<HashMap<String,String>> topicList = new ArrayList<HashMap<String, String>>();
-    private SimpleAdapter topicAdapter;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_title_list);
-        //创建volley请求队列
-        final RequestQueue queue= Volley.newRequestQueue(TitleListActivity.this);
-        //根据API获取热议主题
-        final JsonArrayRequest request = new JsonArrayRequest("http://www.v2ex.com/api/topics/hot.json",new Response.Listener<JSONArray>() {
-            @Override
-            public void onResponse(JSONArray response) {
-                //取id、title、username
-                for (int i=0;i<response.length();i++){
-                    HashMap<String,String> map = new HashMap<String, String>();
-                    try {
-                        map.put("id",response.getJSONObject(i).getString("id"));
-                        map.put("title",response.getJSONObject(i).getString("title"));
-                        map.put("username",response.getJSONObject(i).getJSONObject("member").getString("username"));
-                        map.put("url",response.getJSONObject(i).getString("url"));
-                        topicList.add(map);
-                    } catch (JSONException e) {
-                        e.printStackTrace();
-                    }
-                }
 
-                topicAdapter = new SimpleAdapter(TitleListActivity.this,topicList,R.layout.topic_item,new String[]{"title"},new int[]{R.id.tv_title});
-                lv_title = (ListView)TitleListActivity.this.findViewById(R.id.lv_title);
-                //lv_title.removeAllViews();
-                lv_title.setAdapter(topicAdapter);
-                //加载完毕后progress bar消失
-                pb_load = (ProgressBar)TitleListActivity.this.findViewById(R.id.pb_load);
-                pb_load.setVisibility(View.GONE);
+        final PullToRefreshLayout pullToRefreshLayout = (PullToRefreshLayout) findViewById(R.id.pull);
 
-                lv_title.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                    @Override
-                    public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                        HashMap<String,String> info = (HashMap<String, String>) lv_title.getItemAtPosition(i);
-                        String id = info.get("id");
-                        String title = info.get("title");
-                        String username = info.get("username");
-                        String url = info.get("url");
-                        Intent intent = new Intent(TitleListActivity.this,ContentActivity.class);
-                        intent.putExtra("id",id);
-                        intent.putExtra("title",title);
-                        intent.putExtra("username",username);
-                        intent.putExtra("url",url);
-                        startActivity(intent);
-                    }
-                });
-            }
-        },new Response.ErrorListener() {
+        final List<HashMap<String, String>> topicList = new ArrayList<HashMap<String, String>>();
+
+        final SimpleAdapter topicAdapter = new SimpleAdapter(
+                this,
+                topicList,
+                R.layout.topic_item,
+                new String[]{"title"},
+                new int[]{R.id.tv_title}
+        );
+
+        final ListView lv_title = (ListView) findViewById(R.id.lv_title);
+        lv_title.setAdapter(topicAdapter);
+        lv_title.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
-            public void onErrorResponse(VolleyError error) {
-                Toast.makeText(TitleListActivity.this,"请检查网络",Toast.LENGTH_LONG).show();
+            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                HashMap<String, String> info = (HashMap<String, String>) lv_title.getItemAtPosition(i);
+                String id = info.get("id");
+                String title = info.get("title");
+                String username = info.get("username");
+                String url = info.get("url");
+                Intent intent = new Intent(TitleListActivity.this, ContentActivity.class);
+                intent.putExtra("id", id);
+                intent.putExtra("title", title);
+                intent.putExtra("username", username);
+                intent.putExtra("url", url);
+                startActivity(intent);
             }
         });
 
+        //创建volley请求队列
+        final RequestQueue queue = Volley.newRequestQueue(this);
+
+        //根据API获取热议主题
+        final JsonArrayRequest request = new JsonArrayRequest("http://www.v2ex.com/api/topics/hot.json",
+                new Response.Listener<JSONArray>() {
+                    @Override
+                    public void onResponse(JSONArray response) {
+                        topicList.clear();
+
+                        //取id、title、username
+                        for (int i = 0; i < response.length(); i++) {
+                            HashMap<String, String> map = new HashMap<String, String>();
+                            try {
+                                map.put("id", response.getJSONObject(i).getString("id"));
+                                map.put("title", response.getJSONObject(i).getString("title"));
+                                map.put("username", response.getJSONObject(i).getJSONObject("member").getString("username"));
+                                map.put("url", response.getJSONObject(i).getString("url"));
+                                topicList.add(map);
+                            } catch (JSONException e) {
+                                e.printStackTrace();
+                            }
+                        }
+
+                        topicAdapter.notifyDataSetChanged();
+                        pullToRefreshLayout.setRefreshComplete();
+                    }
+                },
+                new Response.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        Toast.makeText(TitleListActivity.this, "请检查网络", Toast.LENGTH_LONG).show();
+                    }
+                }
+        );
+
+        ActionBarPullToRefresh.from(this)
+                .allChildrenArePullable()
+                .listener(new OnRefreshListener() {
+                    @Override
+                    public void onRefreshStarted(View view) {
+                        queue.add(request);
+                    }
+                })
+                .setup(pullToRefreshLayout);
+
         queue.add(request);
-
-        final PullToRefreshLayout pullToRefreshLayout = (PullToRefreshLayout)TitleListActivity.this.findViewById(R.id.pull);
-        ActionBarPullToRefresh.from(this).allChildrenArePullable().listener(new OnRefreshListener() {
-            @Override
-            public void onRefreshStarted(View view) {
-                //lv_title = (ListView)TitleListActivity.this.findViewById(R.id.lv_title);
-                topicList.clear();
-                topicAdapter.notifyDataSetChanged();
-                queue.add(request);
-                pullToRefreshLayout.setRefreshComplete();
-
-                //Toast.makeText(TitleListActivity.this,"hi",Toast.LENGTH_LONG).show();
-
-            }
-        }).setup(pullToRefreshLayout);
+        pullToRefreshLayout.setRefreshing(true);
     }
-
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.title_list_acitity, menu);
         return true;
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-        if (id == R.id.action_about) {
-            Intent intent = new Intent(TitleListActivity.this,AboutActivity.class);
-            startActivity(intent);
-            return true;
+        switch (item.getItemId()) {
+            case R.id.action_about:
+                Intent intent = new Intent(TitleListActivity.this, AboutActivity.class);
+                startActivity(intent);
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
         }
-        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/res/layout/activity_title_list.xml
+++ b/app/src/main/res/layout/activity_title_list.xml
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<uk.co.senab.actionbarpulltorefresh.library.PullToRefreshLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<uk.co.senab.actionbarpulltorefresh.library.PullToRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/pull"
-    >
-    <ProgressBar
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_margin="@dimen/normal_spacing"
-        android:id="@+id/pb_load" />
+    android:id="@+id/pull">
 
     <ListView
         android:id="@+id/lv_title"


### PR DESCRIPTION
清理了 TitleListActivity 的逻辑：
1. 加载完数据再 `topicList.clear()`，避免刷新的时候列表会消失
2. ListView 只需要初始化一次就行了，加载完数据直接 `topicAdapter.notifyDataSetChanged()`，Adapter 会自己帮你处理视图变更
